### PR TITLE
included unistd.h to allow building with 4.8 compiler

### DIFF
--- a/src/DmxUsbProDevice.cpp
+++ b/src/DmxUsbProDevice.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <iostream> /* TEMP: for user configuration bug warnings */
 #include <math.h> /* for lroundf() */
+#include <unistd.h> /* for usleep() */
 #include "DmxDevice.h"
 #include "DmxUsbProDevice.h"
 


### PR DESCRIPTION
when compiling in ubuntu 14.04 (g++ 4.8) the build fails with a "usleep undeclared" error. so i included the unistd.h header to be able to compile successfully. it did and still does compile successfully with 4.6.
